### PR TITLE
Fix pinch-to-zoom bug in iOS by upgrading to latest Mapbox

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
   <meta name="description" content="Open source map visualization of public art and murals in the Valley of Heart's Delight (Santa Clara Valley, or South Bay Area)">
   <meta name="keywords" content="public art, mural, 408 create, 408, 408 creates, San José, San Jose, South Bay, Bay Area, Code for San José, Code for America, Code for San Jose, Santa Clara Valley, South Bay Area, Valley of the Heart's Delight, NorCal, Northern California, local art, local color, Exhibition District, Empire Seven Studios, SOFA, ESSJ, NSSJ, SJ, SanJo, art box, art map, culture, Silicon Valley">
   <!-- Include the Mapbox GL JS library -->
-  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.js'></script>
-  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.40.1/mapbox-gl.css' rel='stylesheet' />
+  <script src='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl.js'></script>
+  <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v0.53.1/mapbox-gl.css' rel='stylesheet' />
   <!-- Include style CSS and JavaScript -->
   <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
   <script


### PR DESCRIPTION
**Description:**

On iOS Safari, when you try to zoom the map by pinching the page zooms in and out and the map doesn't move. I tracked down a Github issue thread on the mapbox-gl-js repo describing the problem: https://github.com/mapbox/mapbox-gl-js/issues/6095. It looks like a fix shipped in v0.44.2, but this app was using an older version of the library. I upgraded to the latest which fixes the issue and doesn't seem to cause any regressions, but I would do some light testing of things you expect to work to be sure.

**Broken behavior before upgrade:**

![broken](https://user-images.githubusercontent.com/6456757/56005669-7af8a780-5c86-11e9-935e-44db8a87b46a.gif)

**Fixed behavior after upgrade:**

![fixed2](https://user-images.githubusercontent.com/6456757/56005700-9fed1a80-5c86-11e9-9047-6992f60cd399.gif)

**Details:**

* Device: iPhone 8 Plus
* OS: iOS 12.2
* Browser: iOS Safari

