### PR TITLE
Centers view relative to popup status

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -137,11 +137,29 @@
             
             ` 
           +
-          "<br/><br/> Source: " +
-          currentFeature.properties.sourceURL +
-          "</p>"
+          "<br/><br/>" +
+          "<a href='" + currentFeature.properties.sourceURL + "'>Source</a>"
       )
       .addTo(map);
+      
+      let toggleDescription = document.getElementById('toggleDescription');
+      toggleDescription.onclick = function() { 
+        let offset = document.getElementsByClassName('mapboxgl-popup')[0].clientHeight/2*-1;
+        if( this.checked) {
+          console.log();
+          map.flyTo({
+            center: currentFeature.geometry.coordinates,
+            offset: [0, offset],
+            zoom: 15
+          });
+        } else {
+          map.flyTo({
+            center: currentFeature.geometry.coordinates,
+            zoom: 15
+          });
+        }
+      }
+      
   }
 
   function buildLocationList(data) {
@@ -195,8 +213,6 @@
     displayArtist(listing, prop);
     displayAddress(listing, prop);
 
-    // TODO: Pagination so we don't overload external servers
-    // TODO: Scrapper needs to be updated due to changes to the San Jose government's website.
     if (prop.image) { 
       var artImage = listing.appendChild(document.createElement("div"));
       artImage.style.display = "none";
@@ -312,7 +328,7 @@ function selectListing(node) {
   for(let i = 0; i < hiddenProps.length; i++) {
     hiddenProps[i].style.display = "block";
   }
-  console.log(node.getElementsByClassName("thumbnails"));
+  
   if(node.getElementsByClassName("thumbnails").length > 0) {
     node.getElementsByClassName("thumbnails")[0].style.display = "none";
   }


### PR DESCRIPTION
This addresses #91 and makes it so when we click on a popup's 'Read More' the viewport will offset based on the popup box's height and when we hit 'Read Less', the viewport will revert back to centering around the Y-Axis.

There's also a second minor change that wraps the raw URLs into a 'Source' href link.